### PR TITLE
add aur installation intructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ Install the package, e.g. via pip:
 ```
 pip install --upgrade qtile-plasma
 ```
+
+or if you're running arch linux you can find qtile-plasma on Arch User Repository:
+
+```
+pacaur -S qtile-plasma
+```
     
 Add the layout to your config (`~/.config/qtile/config.py`):
 


### PR DESCRIPTION
Hey, 
I've made a PKGBUILD for this package for Arch Linux. Since more often than not people who run Qtile run it on Arch I think this would be a great thing to mention in readme :)   

https://aur.archlinux.org/packages/qtile-plasma/