### PR TITLE
Make default add mode dynamic

### DIFF
--- a/plasma/layout.py
+++ b/plasma/layout.py
@@ -66,6 +66,13 @@ class Plasma(Layout):
         try:
             self.root.restore(new)
         except NotRestorableError:
+            if self.add_mode is None:
+                # If split has landscape proportions, split horizonally by default,
+                # if portrait, split vertically by default
+                if node.width >= node.height:
+                    self.add_mode = AddMode.HORIZONTAL
+                else:
+                    self.add_mode = AddMode.VERTICAL
             node.add_node(new, self.add_mode)
         self.add_mode = None
 


### PR DESCRIPTION
In case user didn't specify add mode explicitly, this update will make the decision dynamically based on proportions of the node that is about to be resized. This makes more sense to me as the default rather than always defaulting to horizontal split.